### PR TITLE
Traverse to parent directory if dst's basename begins with src's basename

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Alec Thomas <alec@swapoff.org>
+Caitlin Potter <caitp@igalia.com>

--- a/ondir.c
+++ b/ondir.c
@@ -46,7 +46,7 @@ const char *src = NULL, *dst = NULL, *home = NULL;
 
 		if (!src) src = argv[i];
 		else
-		if (!dst) dst = argv[i];
+		if (!dst) dst = strdup(argv[i]);
 		else
 			usage("You have already specified src and dst directories");
 	}
@@ -55,6 +55,10 @@ const char *src = NULL, *dst = NULL, *home = NULL;
 		getcwd(cwd, PATH_MAX);
 		dst = cwd;
 	}
+	len = strlen(dst);
+	// If `dst` ends with '/', trim to simplify checks in loop head
+	if (len && dst[len] == '/')
+		((char*)dst)[len] = 0;
 
 	if (src[0] != '/' || dst[0] != '/')
 		fatal("either the source or destination directory is not absolute");
@@ -77,7 +81,7 @@ const char *src = NULL, *dst = NULL, *home = NULL;
 	len = strlen(working);
 
 	/* Traverse up source path */
-	while (strncmp(working, dst, len)) {
+	while (strncmp(working, dst, len) || (dst[len] && dst[len] != '/')) {
 	regmatch_t match[10];
 	struct odpath_t *p;
 
@@ -171,6 +175,8 @@ const char *src = NULL, *dst = NULL, *home = NULL;
 		if (dst[len] == '/') ++len;
 	}
 
+	if (dst && dst != cwd)
+		free((void*)dst);
 	return 0;
 }
 


### PR DESCRIPTION
In the situation `ondir /foo/bar/common /foo/bar/common2`, scripts are not
evaluated, because common2 appears to match common. This patch corrects this
behaviour by traversing to the parent working directory in this situation.

This is useful for myself, because I use ondir to add `${WEBKIT_ROOT}/Tools/Scripts/` to $PATH, and it would be good for scripts to evaluate correctly when I perform `cd ~/git/WebKit2` from `~/git/WebKit`
