### PR TITLE
Support additional configs via ONDIRRC environment var

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+0.3.0
+  * ONDIRRC environment variable is read to load additional configs
+
 0.2.2
   * Added ~ expansion in ~/.ondirrc paths (only works if ~ is first character)
   * Added envar expansion in the definition and bodies of enter/leave sections.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 0.3.0
   * ONDIRRC environment variable is read to load additional configs
+  * Replace leading ./ in patterns with the directory name of configs
 
 0.2.2
   * Added ~ expansion in ~/.ondirrc paths (only works if ~ is first character)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ HEADERS=conf.h ondir.h
 OBJS=conf.o ondir.o
 TARGET=ondir
 
-VERSION=0.2.3
+VERSION=0.3.0
 DESTDIR=
 
 # Add -DUSE_ONENTERLEAVE to CFLAGS to enable support for .onenter/.onleave

--- a/conf.c
+++ b/conf.c
@@ -19,6 +19,8 @@ char *buffer = malloc(2048), *section = malloc(16384);
 struct odpath_t *path = root, *current = NULL;
 FILE *fp;
 int line = 0, sec_size = 0;
+char *file_copy = strdup(file); // Create a copy to avoid modifying original
+char *dir = dirname(file_copy); // Get the directory name
 
 	if (path) while (path->next) path = path->next;
 
@@ -95,7 +97,13 @@ int line = 0, sec_size = 0;
 				paths = calloc(npaths, sizeof(char*));
 
 				for (pathi = 0, tok = strtok(tok, ":"); pathi < npaths; ++pathi, tok = strtok(NULL, ":")) {
-					if (home && tok[0] == '~') {
+					if (tok[0] == '.' && tok[1] == '/') {
+					char tmppath[strlen(dir) + strlen(tok) + 1];
+						strcpy(tmppath, dir);
+						strcat(tmppath, "/");
+						strcat(tmppath, tok + 2); // Skip "./"
+						paths[pathi] = expand_envars(tmppath);
+					} else if (home && tok[0] == '~') {
 					char tmppath[strlen(tok) + strlen(home) + 1];
 
 						strcpy(tmppath, home);
@@ -122,6 +130,7 @@ int line = 0, sec_size = 0;
 	fclose(fp);
 	free(section);
 	free(buffer);
+	free(file_copy);
 	return root;
 }
 

--- a/ondir.c
+++ b/ondir.c
@@ -30,7 +30,7 @@ char onenter[PATH_MAX + 1];
 #endif
 char working[PATH_MAX + 1], cwd[PATH_MAX + 1];
 int len, i;
-const char *src = NULL, *dst = NULL, *home = NULL;
+const char *src = NULL, *dst = NULL, *home = NULL, *rcfile = NULL;
 
 	if (argc < 2)
 		usage("Not enough arguments");
@@ -64,6 +64,12 @@ const char *src = NULL, *dst = NULL, *home = NULL;
 	if ((home = getenv("HOME"))) {
 		snprintf(working, PATH_MAX, "%s/.ondirrc", home);
 		root = load_conf(working, root);
+	}
+
+	if (rcfile = getenv("ONDIRRC")) {
+		if (strnlen(rcfile, PATH_MAX)<PATH_MAX) {
+			root = load_conf(rcfile, root);
+		}
 	}
 
 	/*
@@ -321,6 +327,8 @@ void usage(const char *msg) {
 		"\n"
 		"  <new-directory> is the current working directory. If <new-directory> is\n"
 		"  omitted, the current working directory is obtained via a call to getcwd().\n"
+		"\n"
+		"  ONDIRRC environment variable may be used to load additional config.\n"
 		"\n", msg
 	);
 	exit(1);


### PR DESCRIPTION
Hello. I'd like to share some updates I'm working on. The goal is to enable the use of `ondir` on a per-project basis. To achieve this, I'm adding support for per-project configurations alongside the existing system-wide and user-wide ones.

First, I'm using the ONDIRRC environment variable to load additional configurations. I usually set this variable in each project's `~ projects/whatever/env.sh`, which is then sourced by a shell that's local to the project.

Second, I want all paths within a per-project configuration to be specified relative to the configuration file itself. So, I've added code that translates `enter ./folder` to `enter ~/proj/whatever/folder`, where the base directory is the location of the configuration file.

Please let me know your thoughts on these changes.
